### PR TITLE
feat: add FindCoords API for scanning arbitrary text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,23 @@
 # Changelog
 
+## [v0.3.0] — unreleased
+
+### Added
+
+- `FindCoords(s string, opts ...FindOption) []Match` for locating coordinate
+  substrings in arbitrary text (free-form descriptions, message bodies).
+- `Match` struct with `Start`, `End`, `Text`, `Coord` fields.
+- `FindOption` constructors: `RequireDirection`, `OnlyLat`, `OnlyLon`.
+- `CoordRegexSource() string` returning the non-capturing regex source for
+  one coordinate, suitable for embedding into user-defined patterns.
+
+### Changed
+
+- Internal coordinate regex refactored into shared building blocks
+  (`rxNum`, `rxDegSep`, `rxMinSep`, `rxSecSep`) plus a non-capturing core
+  reused by `CoordRegexSource`. `ParseCoord`/`ParsePoint` behavior is
+  unchanged.
+
 ## [v0.2.2] by 2026-02-25
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -34,6 +34,11 @@ go get github.com/o-kos/geoc
   - `ParseCoord(s string) (Coord, error)`
 - Parse point:
   - `ParsePoint(s string) (Point, error)`
+- Find coordinates inside arbitrary text:
+  - `FindCoords(s string, opts ...FindOption) []Match`
+  - Options: `RequireDirection`, `OnlyLat`, `OnlyLon`
+- Embed the coordinate regex into your own patterns:
+  - `CoordRegexSource() string`
 - Format coordinate by example:
   - `Coord.Format(example string) (string, error)`
 - Format point by examples:
@@ -62,6 +67,33 @@ Deprecated wrappers are still available:
   - longitude: `048-33.0E`
   - unspecified location: decimal degrees
 - `Point.String()` uses `48-33.0N 048-33.0E`.
+
+## Finding coordinates in text
+
+`FindCoords` scans an arbitrary string and returns every coordinate
+substring it can parse, in order of appearance. Useful for free-form
+inputs such as NAVTEX message bodies:
+
+```go
+text := "WARNING 175/22 - mines reported near 39 27 25.55N - 009 39 25E, " +
+    "stay clear within 3 NM."
+
+for _, m := range geoc.FindCoords(text, geoc.RequireDirection()) {
+    fmt.Printf("%d-%d %s %q\n", m.Start, m.End, m.Coord.Loc, m.Text)
+}
+// Output:
+// 37-49 Lat "39 27 25.55N"
+// 52-62 Lon "009 39 25E"
+```
+
+The `175/22` message number, surrounding noise, and `3 NM` (nautical
+miles) are correctly skipped.
+
+`RequireDirection` skips matches without an `N/S/E/W` letter (dates,
+message numbers, distances). `OnlyLat` / `OnlyLon` further restrict to
+one axis. To embed the same coordinate regex into your own pattern, use
+`CoordRegexSource()` — it returns a non-capturing source string with no
+surrounding whitespace.
 
 ## Benchmarks
 

--- a/example_test.go
+++ b/example_test.go
@@ -58,6 +58,24 @@ func ExamplePoint_Format() {
 	// 48°33'27"N; 120°57'49"E
 }
 
+func ExampleFindCoords() {
+	text := "WARNING 175/22 - mines reported near 39 27 25.55N - 009 39 25E, " +
+		"stay clear within 3 NM."
+	for _, m := range FindCoords(text, RequireDirection()) {
+		fmt.Printf("%d-%d %s %q\n", m.Start, m.End, m.Coord.Loc, m.Text)
+	}
+	// Output:
+	// 37-49 Lat "39 27 25.55N"
+	// 52-62 Lon "009 39 25E"
+}
+
+func ExampleCoordRegexSource() {
+	src := CoordRegexSource()
+	fmt.Println(len(src) > 0)
+	// Output:
+	// true
+}
+
 func ExamplePoint_String() {
 	p := Point{
 		Lat: Coord{Value: 48.5575, Loc: LocLat},

--- a/find.go
+++ b/find.go
@@ -95,7 +95,7 @@ func FindCoords(s string, opts ...FindOption) []Match {
 		// this check the regex would treat such fragments as coords.
 		if cg.loc != "" {
 			locEnd := idx[2*locGroupIndex+1]
-			if locEnd >= 0 && locEnd < len(s) && isAsciiLetter(s[locEnd]) {
+			if locEnd >= 0 && locEnd < len(s) && isASCIILetter(s[locEnd]) {
 				continue
 			}
 		}
@@ -128,7 +128,7 @@ func FindCoords(s string, opts ...FindOption) []Match {
 	return out
 }
 
-func isAsciiLetter(b byte) bool {
+func isASCIILetter(b byte) bool {
 	return (b >= 'a' && b <= 'z') || (b >= 'A' && b <= 'Z')
 }
 
@@ -137,16 +137,16 @@ func isAsciiLetter(b byte) bool {
 // separators when no further coord component followed. Matches RE2's \s
 // class: space, tab, newline, carriage return, form feed, vertical tab.
 func trimMatchSpan(s string, start, end int) (int, int) {
-	for start < end && isAsciiSpace(s[start]) {
+	for start < end && isASCIISpace(s[start]) {
 		start++
 	}
-	for end > start && isAsciiSpace(s[end-1]) {
+	for end > start && isASCIISpace(s[end-1]) {
 		end--
 	}
 	return start, end
 }
 
-func isAsciiSpace(b byte) bool {
+func isASCIISpace(b byte) bool {
 	switch b {
 	case ' ', '\t', '\n', '\r', '\f', '\v':
 		return true

--- a/find.go
+++ b/find.go
@@ -1,0 +1,124 @@
+package geoc
+
+import (
+	"unicode"
+)
+
+// Match describes a coordinate located inside arbitrary text.
+type Match struct {
+	Start, End int    // byte offsets in the input string
+	Text       string // raw substring from the input, equal to s[Start:End]
+	Coord      Coord  // parsed coordinate; Loc is set when N/S/E/W is present
+}
+
+// FindOption configures FindCoords behavior.
+type FindOption func(*findConfig)
+
+type findConfig struct {
+	requireDirection bool
+	onlyLoc          Location
+}
+
+// RequireDirection makes FindCoords skip matches that lack an N/S/E/W letter.
+// Useful for filtering out bare numeric tokens (dates, message numbers,
+// distances) that would otherwise look like decimal-degree coordinates.
+func RequireDirection() FindOption {
+	return func(c *findConfig) { c.requireDirection = true }
+}
+
+// OnlyLat keeps only matches whose Coord.Loc is LocLat.
+// Implies RequireDirection (latitude is determined by the N/S letter).
+func OnlyLat() FindOption {
+	return func(c *findConfig) {
+		c.requireDirection = true
+		c.onlyLoc = LocLat
+	}
+}
+
+// OnlyLon keeps only matches whose Coord.Loc is LocLon.
+// Implies RequireDirection (longitude is determined by the E/W letter).
+func OnlyLon() FindOption {
+	return func(c *findConfig) {
+		c.requireDirection = true
+		c.onlyLoc = LocLon
+	}
+}
+
+// CoordRegexSource returns the regex source string that matches one
+// coordinate. It contains no capture groups and no surrounding whitespace,
+// so it can be safely embedded into user-defined patterns.
+//
+// The returned source matches the same set of substrings that FindCoords
+// considers as coordinate candidates (parsing may still reject them).
+func CoordRegexSource() string {
+	return coordRegexCore
+}
+
+// FindCoords returns all coordinate occurrences inside s, in order of
+// appearance. Candidates that fail to parse are skipped silently.
+func FindCoords(s string, opts ...FindOption) []Match {
+	cfg := findConfig{}
+	for _, opt := range opts {
+		opt(&cfg)
+	}
+
+	subNames := coordRegExp.SubexpNames()
+	allIdx := coordRegExp.FindAllStringSubmatchIndex(s, -1)
+	if len(allIdx) == 0 {
+		return nil
+	}
+
+	out := make([]Match, 0, len(allIdx))
+	for _, idx := range allIdx {
+		groups := make([]string, len(subNames))
+		for i := range subNames {
+			gStart, gEnd := idx[2*i], idx[2*i+1]
+			if gStart >= 0 {
+				groups[i] = s[gStart:gEnd]
+			}
+		}
+
+		cg, _ := coordGroupsFromMatch(groups, subNames)
+		cg.normalizeDotDMS()
+		cg.normalizeCompact()
+
+		coord, err := cg.getCoord()
+		if err != nil {
+			continue
+		}
+
+		if cfg.requireDirection && cg.loc == "" {
+			continue
+		}
+		if cfg.onlyLoc != LocNone && coord.Loc != cfg.onlyLoc {
+			continue
+		}
+
+		start, end := trimMatchSpan(s, idx[0], idx[1])
+		if start >= end {
+			continue
+		}
+
+		out = append(out, Match{
+			Start: start,
+			End:   end,
+			Text:  s[start:end],
+			Coord: coord,
+		})
+	}
+
+	return out
+}
+
+// trimMatchSpan returns [start, end] adjusted to exclude leading/trailing
+// ASCII whitespace that the regex may have consumed via its outer (\s*)
+// groups or via inner separators when no further coord component followed.
+func trimMatchSpan(s string, start, end int) (int, int) {
+	for start < end && unicode.IsSpace(rune(s[start])) {
+		start++
+	}
+	for end > start && unicode.IsSpace(rune(s[end-1])) {
+		end--
+	}
+	return start, end
+}

--- a/find.go
+++ b/find.go
@@ -54,6 +54,17 @@ func CoordRegexSource() string {
 	return coordRegexCore
 }
 
+// locGroupIndex is the position of the named "loc" group in
+// coordRegExp.SubexpNames(). Cached at init for quick access in FindCoords.
+var locGroupIndex = func() int {
+	for i, name := range coordRegExp.SubexpNames() {
+		if name == "loc" {
+			return i
+		}
+	}
+	return -1
+}()
+
 // FindCoords returns all coordinate occurrences inside s, in order of
 // appearance. Candidates that fail to parse are skipped silently.
 func FindCoords(s string, opts ...FindOption) []Match {
@@ -82,6 +93,17 @@ func FindCoords(s string, opts ...FindOption) []Match {
 		cg.normalizeDotDMS()
 		cg.normalizeCompact()
 
+		// If the loc letter is glued to another letter (e.g. "N" in "NM"
+		// for nautical miles, "S" in "SE", "E" in "End"), it is part of
+		// a word, not a direction marker. Drop the candidate — without
+		// this check the regex would treat such fragments as coords.
+		if cg.loc != "" {
+			locEnd := idx[2*locGroupIndex+1]
+			if locEnd >= 0 && locEnd < len(s) && isAsciiLetter(s[locEnd]) {
+				continue
+			}
+		}
+
 		coord, err := cg.getCoord()
 		if err != nil {
 			continue
@@ -108,6 +130,10 @@ func FindCoords(s string, opts ...FindOption) []Match {
 	}
 
 	return out
+}
+
+func isAsciiLetter(b byte) bool {
+	return (b >= 'a' && b <= 'z') || (b >= 'A' && b <= 'Z')
 }
 
 // trimMatchSpan returns [start, end] adjusted to exclude leading/trailing

--- a/find.go
+++ b/find.go
@@ -1,9 +1,5 @@
 package geoc
 
-import (
-	"unicode"
-)
-
 // Match describes a coordinate located inside arbitrary text.
 type Match struct {
 	Start, End int    // byte offsets in the input string
@@ -136,15 +132,24 @@ func isAsciiLetter(b byte) bool {
 	return (b >= 'a' && b <= 'z') || (b >= 'A' && b <= 'Z')
 }
 
-// trimMatchSpan returns [start, end] adjusted to exclude leading/trailing
-// ASCII whitespace that the regex may have consumed via its outer (\s*)
-// groups or via inner separators when no further coord component followed.
+// trimMatchSpan returns [start, end] adjusted to exclude ASCII whitespace
+// that the regex may have consumed via its outer (\s*) groups or via inner
+// separators when no further coord component followed. Matches RE2's \s
+// class: space, tab, newline, carriage return, form feed, vertical tab.
 func trimMatchSpan(s string, start, end int) (int, int) {
-	for start < end && unicode.IsSpace(rune(s[start])) {
+	for start < end && isAsciiSpace(s[start]) {
 		start++
 	}
-	for end > start && unicode.IsSpace(rune(s[end-1])) {
+	for end > start && isAsciiSpace(s[end-1]) {
 		end--
 	}
 	return start, end
+}
+
+func isAsciiSpace(b byte) bool {
+	switch b {
+	case ' ', '\t', '\n', '\r', '\f', '\v':
+		return true
+	}
+	return false
 }

--- a/find_test.go
+++ b/find_test.go
@@ -1,0 +1,228 @@
+package geoc
+
+import (
+	"strings"
+	"testing"
+)
+
+// findCase describes one input string and the expected list of coordinate
+// substrings FindCoords should return for it (in order).
+type findCase struct {
+	name  string
+	input string
+	opts  []FindOption
+	want  []string // expected Match.Text values, in order
+}
+
+func runFindCases(t *testing.T, cases []findCase) {
+	t.Helper()
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := FindCoords(tc.input, tc.opts...)
+			if len(got) != len(tc.want) {
+				gotTexts := make([]string, len(got))
+				for i, m := range got {
+					gotTexts[i] = m.Text
+				}
+				t.Fatalf("got %d matches %q, want %d %q",
+					len(got), gotTexts, len(tc.want), tc.want)
+			}
+			for i, m := range got {
+				if m.Text != tc.want[i] {
+					t.Errorf("match %d: Text = %q, want %q", i, m.Text, tc.want[i])
+				}
+				if tc.input[m.Start:m.End] != m.Text {
+					t.Errorf("match %d: s[%d:%d]=%q != Text=%q",
+						i, m.Start, m.End, tc.input[m.Start:m.End], m.Text)
+				}
+			}
+		})
+	}
+}
+
+func TestFindCoordsPositive(t *testing.T) {
+	runFindCases(t, []findCase{
+		{
+			name:  "dms_with_decimal_seconds",
+			input: "msg 39 27 25.55N body",
+			opts:  []FindOption{RequireDirection()},
+			want:  []string{"39 27 25.55N"},
+		},
+		{
+			name:  "decimal_comma_greek",
+			input: "pos 35 32,00N here",
+			opts:  []FindOption{RequireDirection()},
+			want:  []string{"35 32,00N"},
+		},
+		{
+			name:  "line_break_inside_coord",
+			input: "lat 38-\n34.2N text",
+			opts:  []FindOption{RequireDirection()},
+			want:  []string{"38-\n34.2N"},
+		},
+		{
+			name:  "dms_sign_separators",
+			input: `at 35°32'15"N now`,
+			opts:  []FindOption{RequireDirection()},
+			want:  []string{`35°32'15"N`},
+		},
+		{
+			name:  "truncated_deg_min",
+			input: "x 40 30N y",
+			opts:  []FindOption{RequireDirection()},
+			want:  []string{"40 30N"},
+		},
+		{
+			name:  "truncated_deg_only",
+			input: "x 40N y",
+			opts:  []FindOption{RequireDirection()},
+			want:  []string{"40N"},
+		},
+		{
+			name:  "truncated_decimal_deg",
+			input: "x 40.5N y",
+			opts:  []FindOption{RequireDirection()},
+			want:  []string{"40.5N"},
+		},
+		{
+			name:  "navtex_pair_with_dash_separator",
+			input: "39 27 25.55N - 009 39 25E",
+			opts:  []FindOption{RequireDirection()},
+			want:  []string{"39 27 25.55N", "009 39 25E"},
+		},
+		{
+			name:  "pair_with_comma_separator",
+			input: "lat 39 27N, lon 40 30E end",
+			opts:  []FindOption{RequireDirection()},
+			want:  []string{"39 27N", "40 30E"},
+		},
+	})
+}
+
+func TestFindCoordsNegativeWithRequireDirection(t *testing.T) {
+	// Inputs that look numeric but contain no N/S/E/W must yield zero
+	// matches when RequireDirection() is active.
+	cases := []findCase{
+		{name: "iso_date", input: "2022 03 15", want: nil},
+		{name: "navtex_message_number", input: "175/22 MAR 15", want: nil},
+		{name: "distance_nm", input: "3 NM", want: nil},
+		{name: "distance_metres", input: "1500 METRES", want: nil},
+		{name: "zone_id", input: "BR-12", want: nil},
+	}
+	for i := range cases {
+		cases[i].opts = []FindOption{RequireDirection()}
+	}
+	runFindCases(t, cases)
+}
+
+func TestFindCoordsBoundary(t *testing.T) {
+	t.Run("position_excludes_surrounding_whitespace", func(t *testing.T) {
+		input := "   39 27N   "
+		got := FindCoords(input, RequireDirection())
+		if len(got) != 1 {
+			t.Fatalf("got %d matches, want 1", len(got))
+		}
+		m := got[0]
+		if m.Text != "39 27N" {
+			t.Errorf("Text = %q, want %q", m.Text, "39 27N")
+		}
+		if input[m.Start:m.End] != m.Text {
+			t.Errorf("s[%d:%d]=%q != Text=%q", m.Start, m.End,
+				input[m.Start:m.End], m.Text)
+		}
+		if m.Start != 3 || m.End != 9 {
+			t.Errorf("Start/End = %d/%d, want 3/9", m.Start, m.End)
+		}
+	})
+
+	t.Run("substring_invariant_on_complex_text", func(t *testing.T) {
+		// Several coords mixed with noise; every returned match must
+		// satisfy s[Start:End] == Text.
+		input := "  alpha 39 27 25.55N - 009 39 25E beta 40N gamma  "
+		got := FindCoords(input, RequireDirection())
+		if len(got) == 0 {
+			t.Fatal("no matches")
+		}
+		for i, m := range got {
+			if input[m.Start:m.End] != m.Text {
+				t.Errorf("match %d: s[%d:%d]=%q != Text=%q",
+					i, m.Start, m.End, input[m.Start:m.End], m.Text)
+			}
+			if strings.HasPrefix(m.Text, " ") || strings.HasSuffix(m.Text, " ") {
+				t.Errorf("match %d: Text %q has surrounding whitespace",
+					i, m.Text)
+			}
+		}
+	})
+
+	t.Run("adjacent_coords_no_whitespace_separator", func(t *testing.T) {
+		input := "39N40E"
+		got := FindCoords(input, RequireDirection())
+		want := []string{"39N", "40E"}
+		if len(got) != len(want) {
+			gotTexts := make([]string, len(got))
+			for i, m := range got {
+				gotTexts[i] = m.Text
+			}
+			t.Fatalf("got %d matches %q, want %d %q",
+				len(got), gotTexts, len(want), want)
+		}
+		for i, m := range got {
+			if m.Text != want[i] {
+				t.Errorf("match %d: Text = %q, want %q", i, m.Text, want[i])
+			}
+			if input[m.Start:m.End] != m.Text {
+				t.Errorf("match %d: s[Start:End] mismatch", i)
+			}
+		}
+	})
+}
+
+func TestFindCoordsOnlyLatOnlyLon(t *testing.T) {
+	input := "lat 39 27N body 40 30E end"
+
+	t.Run("only_lat", func(t *testing.T) {
+		got := FindCoords(input, OnlyLat())
+		if len(got) != 1 {
+			t.Fatalf("got %d matches, want 1", len(got))
+		}
+		if got[0].Text != "39 27N" {
+			t.Errorf("Text = %q, want %q", got[0].Text, "39 27N")
+		}
+		if got[0].Coord.Loc != LocLat {
+			t.Errorf("Loc = %s, want Lat", got[0].Coord.Loc)
+		}
+	})
+
+	t.Run("only_lon", func(t *testing.T) {
+		got := FindCoords(input, OnlyLon())
+		if len(got) != 1 {
+			t.Fatalf("got %d matches, want 1", len(got))
+		}
+		if got[0].Text != "40 30E" {
+			t.Errorf("Text = %q, want %q", got[0].Text, "40 30E")
+		}
+		if got[0].Coord.Loc != LocLon {
+			t.Errorf("Loc = %s, want Lon", got[0].Coord.Loc)
+		}
+	})
+}
+
+func TestCoordRegexSourceEmbeddable(t *testing.T) {
+	// CoordRegexSource() output must be safe to embed inside a user-defined
+	// named group: it must not contain capture-group syntax of its own.
+	src := CoordRegexSource()
+	if src == "" {
+		t.Fatal("CoordRegexSource returned empty string")
+	}
+	if strings.Contains(src, "(?P<") {
+		t.Errorf("source contains named capture group: %q", src)
+	}
+	// Plain ( that is not part of (?: or (?= etc indicates a capturing group.
+	for i := 0; i < len(src)-1; i++ {
+		if src[i] == '(' && src[i+1] != '?' {
+			t.Errorf("source contains capturing group at offset %d: %q", i, src)
+			break
+		}
+	}
+}

--- a/geoc.go
+++ b/geoc.go
@@ -376,12 +376,31 @@ func (cg *coordGroups) getFormatClass() formatClass {
 	return dms
 }
 
+// Shared building blocks for the coordinate regex. coordRegexCore (the
+// non-capturing source returned by CoordRegexSource) and coordRegExp (the
+// named-group version used by ParseCoord/ParsePoint) reuse these so the two
+// stay structurally in sync.
+const (
+	rxNum    = `\d+(?:[\.,]\d+)?`
+	rxDegSep = `\s*[-°\.]?\s*`
+	rxMinSep = `\s*[-'\.]?\s*`
+	rxSecSep = `\s*[ "]?\s*`
+)
+
+// coordRegexCore matches a single coordinate without capture groups and
+// without surrounding whitespace. Suitable for embedding into user patterns.
+const coordRegexCore = `[-+]?` +
+	`(?:` + rxNum + `(?:` + rxDegSep + `)?)` +
+	`(?:` + rxNum + `(?:` + rxMinSep + `)?)?` +
+	`(?:` + rxNum + `(?:` + rxSecSep + `)?)?` +
+	`[NSEW]?`
+
 var coordRegExp = regexp.MustCompile(
 	`(\s*)` +
 		`(?P<sgn>[-+])?` +
-		`(?:(?P<deg>\d+(?:[\.,]\d+)?)(?P<dsr>\s*[-°\.]?\s*)?)` +
-		`(?:(?P<min>\d+(?:[\.,]\d+)?)(?P<msr>\s*[-'\.]?\s*)?)?` +
-		`(?:(?P<sec>\d+(?:[\.,]\d+)?)(?P<ssr>\s*[ "]?\s*)?)?` +
+		`(?:(?P<deg>` + rxNum + `)(?P<dsr>` + rxDegSep + `)?)` +
+		`(?:(?P<min>` + rxNum + `)(?P<msr>` + rxMinSep + `)?)?` +
+		`(?:(?P<sec>` + rxNum + `)(?P<ssr>` + rxSecSep + `)?)?` +
 		`(?P<loc>[NSEW])?(\s*)`,
 )
 

--- a/geoc.go
+++ b/geoc.go
@@ -84,9 +84,10 @@ func (c Coord) Format(example string) (string, error) {
 	// Use Coord's Loc if set, otherwise derive from example
 	loc := c.Loc
 	if loc == LocNone {
-		if cg.loc == "N" || cg.loc == "S" {
+		switch cg.loc {
+		case "N", "S":
 			loc = LocLat
-		} else if cg.loc == "E" || cg.loc == "W" {
+		case "E", "W":
 			loc = LocLon
 		}
 	}
@@ -117,11 +118,12 @@ func (c Coord) Format(example string) (string, error) {
 			precision = len(s) - idx - 1
 		}
 	}
-	if hasSec && !cg.compact {
+	switch {
+	case hasSec && !cg.compact:
 		detectDecimal(cg.sec)
-	} else if hasMin && !cg.compact {
+	case hasMin && !cg.compact:
 		detectDecimal(cg.min)
-	} else if !hasMin {
+	case !hasMin:
 		detectDecimal(cg.deg)
 	}
 
@@ -157,16 +159,15 @@ func (c Coord) Format(example string) (string, error) {
 	// Determine output location letter
 	locLetter := ""
 	if cg.loc != "" {
-		if loc == LocLat {
+		switch {
+		case loc == LocLat && negative:
+			locLetter = "S"
+		case loc == LocLat:
 			locLetter = "N"
-			if negative {
-				locLetter = "S"
-			}
-		} else {
+		case negative:
+			locLetter = "W"
+		default:
 			locLetter = "E"
-			if negative {
-				locLetter = "W"
-			}
 		}
 	}
 	applySign := func(body string) string {
@@ -518,13 +519,12 @@ func isPointSeparator(s string) bool {
 }
 
 func (cg *coordGroups) getLocation() (Location, error) {
-	if cg.loc == "N" || cg.loc == "S" {
+	switch cg.loc {
+	case "N", "S":
 		return LocLat, nil
-	}
-	if cg.loc == "E" || cg.loc == "W" {
+	case "E", "W":
 		return LocLon, nil
-	}
-	if cg.loc == "" {
+	case "":
 		return LocNone, nil
 	}
 


### PR DESCRIPTION
Closes #10.

Adds `FindCoords(s, opts...) []Match` for locating coordinates inside
arbitrary text (NAVTEX message bodies, free-form descriptions, etc.).
Existing `ParseCoord`/`ParsePoint` behavior is unchanged.

## API additions

- `Match` struct (`Start`, `End`, `Text`, `Coord`).
- `FindCoords(s string, opts ...FindOption) []Match`.
- `FindOption` constructors: `RequireDirection`, `OnlyLat`, `OnlyLon`.
- `CoordRegexSource() string` — non-capturing regex source for embedding
  the coord pattern into user-defined patterns. (Was in the original
  issue proposal; kept because it removes another drift vector for
  downstream consumers.)

## Implementation notes

- Internal regex split into shared building blocks (`rxNum`, `rxDegSep`,
  `rxMinSep`, `rxSecSep`) plus a non-capturing `coordRegexCore`. The
  named-group `coordRegExp` reuses the same blocks, so the two stay in
  sync. `ParseCoord`/`ParsePoint` are byte-for-byte equivalent.
- Find-level word-boundary heuristic: a candidate is dropped when its
  N/S/E/W letter is glued to another ASCII letter (e.g. \`3 NM\` would
  otherwise yield a 3°N false-positive). Does not touch `ParseCoord`.
- `Match.Start`/`End` are trimmed of whitespace consumed by the regex's
  outer or inner separators, so `s[Start:End] == Text` always holds.

## Scope departures from the plan

- Compact \`4030N\` / \`403000N\` (DDMM[SS] without separator) listed as
  positive cases are **not supported** — `ParseCoord` itself only handles
  compact MMSS with a separator (e.g. \`120-5749E\`). Out of scope for
  this PR; can be a follow-up if needed.
- Three pre-existing if/else-if chains in `geoc.go` rewritten as
  idiomatic switches (staticcheck QF1003, gocritic ifElseChain, nestif).
  Kept as a separate commit so it can be split out if reviewer prefers.

## Tests

Table-driven `find_test.go` covers:
- DMS-with-decimal-seconds, decimal-comma, line-break-inside-coord, DMS
  sign separators, truncated forms (deg+min, deg-only, decimal-deg).
- Multi-coord strings with various separators.
- Negative cases under `RequireDirection`: ISO date, NAVTEX message
  number, distance units (NM, METRES), zone IDs.
- Boundary: surrounding whitespace stripping, `s[Start:End] == Text`
  invariant on complex inputs, adjacent coords without a separator.
- `OnlyLat` / `OnlyLon` filtering.

`go test ./...` and `golangci-lint` (~80 enabled rules) — both clean.

## Reviewer checklist

- [ ] `ParseCoord`/`ParsePoint` tests still pass (no behavior change).
- [ ] `s[Match.Start:Match.End] == Match.Text` for every returned match.
- [ ] `RequireDirection()` rejects all negative-case fixtures.
- [ ] README + CHANGELOG updated (`v0.3.0 — unreleased`; will be dated
      in a release-commit on main per Keep a Changelog convention).