### PR TITLE
fix: tighten FindCoords letter-glue and cross-line matching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,25 @@
 # Changelog
 
+## [v0.3.2] — unreleased
+
+### Fixed
+
+- `FindCoords` no longer mismatches the `N`/`S` in distance abbreviations
+  like `1 N.M.`, `5 S.M.`, or `10 N MILE` as a coordinate.
+- `FindCoords` now recovers a real coordinate that follows a noise number
+  separated by a line break, e.g. `BR-117\n55-54.0N` returns `55-54.0N`
+  instead of being lost inside the oversized 117° candidate.
+- `FindCoords` accepts a fully-specified DMS coord glued to a non-coord
+  word (NAVTEX terminator `NNN`, message word `END`, etc.), so
+  `124-50-00ENNN` returns `124-50-00E`.
+
+### Changed
+
+- Internal coordinate regex: `\n` between deg and min components is now
+  allowed only when bridged by an explicit `-`/`°`/`.` separator (the
+  intra-coord linebreak shape `38-\n34.2N`). This affects `CoordRegexSource`
+  too and is what enables the cross-line fix above.
+
 ## [v0.3.1] by 2026-04-29
 
 ### Changed

--- a/find.go
+++ b/find.go
@@ -1,5 +1,13 @@
 package geoc
 
+import "regexp"
+
+// unitSuffixRE matches a distance-unit abbreviation glued to a direction
+// letter. When this matches the bytes immediately after the loc letter, the
+// candidate is a distance fragment ("1 N.M.", "5 S.M.", "10 N MILE", "5 KM"),
+// not a coordinate.
+var unitSuffixRE = regexp.MustCompile(`(?i)^\.?[ \t]*(?:M\.|MILE\b|MI\b|KM\b)`)
+
 // Match describes a coordinate located inside arbitrary text.
 type Match struct {
 	Start, End int    // byte offsets in the input string
@@ -63,6 +71,11 @@ var locGroupIndex = func() int {
 
 // FindCoords returns all coordinate occurrences inside s, in order of
 // appearance. Candidates that fail to parse are skipped silently.
+//
+// FindCoords runs a manual scan loop rather than FindAllStringSubmatchIndex
+// so that when a candidate is dropped (out-of-range degrees, glued unit
+// suffix, RequireDirection mismatch) the search can recover a real coord
+// hidden inside the dropped span: see TestFindCoordsNoCrossLineGreedy.
 func FindCoords(s string, opts ...FindOption) []Match {
 	cfg := findConfig{}
 	for _, opt := range opts {
@@ -70,13 +83,23 @@ func FindCoords(s string, opts ...FindOption) []Match {
 	}
 
 	subNames := coordRegExp.SubexpNames()
-	allIdx := coordRegExp.FindAllStringSubmatchIndex(s, -1)
-	if len(allIdx) == 0 {
-		return nil
-	}
+	var out []Match
+	pos := 0
 
-	out := make([]Match, 0, len(allIdx))
-	for _, idx := range allIdx {
+	for pos < len(s) {
+		rel := coordRegExp.FindStringSubmatchIndex(s[pos:])
+		if rel == nil {
+			break
+		}
+		idx := make([]int, len(rel))
+		for i, v := range rel {
+			if v < 0 {
+				idx[i] = v
+			} else {
+				idx[i] = v + pos
+			}
+		}
+
 		groups := make([]string, len(subNames))
 		for i := range subNames {
 			gStart, gEnd := idx[2*i], idx[2*i+1]
@@ -89,31 +112,29 @@ func FindCoords(s string, opts ...FindOption) []Match {
 		cg.normalizeDotDMS()
 		cg.normalizeCompact()
 
-		// If the loc letter is glued to another letter (e.g. "N" in "NM"
-		// for nautical miles, "S" in "SE", "E" in "End"), it is part of
-		// a word, not a direction marker. Drop the candidate — without
-		// this check the regex would treat such fragments as coords.
-		if cg.loc != "" {
-			locEnd := idx[2*locGroupIndex+1]
-			if locEnd >= 0 && locEnd < len(s) && isASCIILetter(s[locEnd]) {
-				continue
-			}
+		if !acceptLetterGlue(s, idx[2*locGroupIndex+1], &cg) {
+			pos = idx[0] + 1
+			continue
 		}
 
 		coord, err := cg.getCoord()
 		if err != nil {
+			pos = idx[0] + 1
 			continue
 		}
 
 		if cfg.requireDirection && cg.loc == "" {
+			pos = idx[0] + 1
 			continue
 		}
 		if cfg.onlyLoc != LocNone && coord.Loc != cfg.onlyLoc {
+			pos = idx[1]
 			continue
 		}
 
 		start, end := trimMatchSpan(s, idx[0], idx[1])
 		if start >= end {
+			pos = idx[1]
 			continue
 		}
 
@@ -123,9 +144,51 @@ func FindCoords(s string, opts ...FindOption) []Match {
 			Text:  s[start:end],
 			Coord: coord,
 		})
+		pos = idx[1]
 	}
 
 	return out
+}
+
+// acceptLetterGlue reports whether a candidate's loc letter is followed by
+// bytes that should make us drop it. Returns true to keep the candidate.
+//
+// The check is in two parts:
+//
+//   - Unit suffix (".M.", " MILE", "KM" etc.): always drops, since the
+//     direction letter is part of a distance token, not a coordinate.
+//   - Plain letter glue (e.g. "1NORTH", "3 NM"): drops minimal candidates
+//     (no min/sec) where the trailing word could be anything, but accepts
+//     fully-specified DMS candidates whose trailing letters can't form a
+//     coord on their own (NAVTEX terminator "NNN", message words like
+//     "END"/"AREA"). See TestFindCoordsGluedToTerminator.
+func acceptLetterGlue(s string, locEnd int, cg *coordGroups) bool {
+	if cg.loc == "" || locEnd < 0 || locEnd >= len(s) {
+		return true
+	}
+	rest := s[locEnd:]
+	if unitSuffixRE.MatchString(rest) {
+		return false
+	}
+	if !isASCIILetter(rest[0]) {
+		return true
+	}
+	// Trailing letter glue. Keep the candidate only if it has full DMS
+	// structure (deg+min+sec) AND the trailing alphanumeric run contains
+	// no digits — i.e. it's a word, not another glued coord.
+	if cg.sec == "" {
+		return false
+	}
+	for i := 0; i < len(rest); i++ {
+		c := rest[i]
+		if c >= '0' && c <= '9' {
+			return false
+		}
+		if !isASCIILetter(c) {
+			break
+		}
+	}
+	return true
 }
 
 func isASCIILetter(b byte) bool {

--- a/find_test.go
+++ b/find_test.go
@@ -208,6 +208,90 @@ func TestFindCoordsOnlyLatOnlyLon(t *testing.T) {
 	})
 }
 
+func TestFindCoordsUnitSuffixRejected(t *testing.T) {
+	// Direction letters glued to a unit abbreviation ("1 N.M.", "5 S.M.")
+	// must not be accepted as coordinates — the trailing dot makes the
+	// naive one-byte letter-glue check pass, so the regex needs a proper
+	// look-ahead for known distance units.
+	cases := []findCase{
+		{name: "nautical_mile_dotted", input: "1 N.M.", want: nil},
+		{name: "statute_mile_dotted", input: "5 S.M.", want: nil},
+		{name: "nautical_mile_radius", input: "RADIUS 1 N.M.", want: nil},
+		{name: "nautical_mile_within", input: "WITHIN 10 N.M. OF", want: nil},
+		// Counter-cases: real coords must keep matching.
+		{
+			name:  "real_coord_pair",
+			input: "1N 2E",
+			want:  []string{"1N", "2E"},
+		},
+		{
+			name:  "direction_with_period_then_word",
+			input: "1N. AREA",
+			want:  []string{"1N"},
+		},
+	}
+	for i := range cases {
+		cases[i].opts = []FindOption{RequireDirection()}
+	}
+	runFindCases(t, cases)
+}
+
+func TestFindCoordsNoCrossLineGreedy(t *testing.T) {
+	// A noise number followed by a real coordinate on the next line must
+	// not collapse into a single oversized candidate that swallows the
+	// real coord ("BR-117\n55-54.0N" used to lose the 55-54.0N match
+	// because deg=117 ate the linebreak).
+	cases := []findCase{
+		{
+			name:  "navtex_zone_then_pair",
+			input: "BR-117\n55-54.0N 019-03.0E",
+			want:  []string{"55-54.0N", "019-03.0E"},
+		},
+		{
+			name:  "header_line_then_pair",
+			input: "FROM 192200 UTC\n34-35.6N 139-49.2E",
+			want:  []string{"34-35.6N", "139-49.2E"},
+		},
+		// Counter-case: a hyphen-bridged linebreak inside one coord must
+		// stay as a single match.
+		{
+			name:  "intra_coord_linebreak_after_dash",
+			input: "lat 38-\n34.2N text",
+			want:  []string{"38-\n34.2N"},
+		},
+	}
+	for i := range cases {
+		cases[i].opts = []FindOption{RequireDirection()}
+	}
+	runFindCases(t, cases)
+}
+
+func TestFindCoordsGluedToTerminator(t *testing.T) {
+	// A fully-specified coord glued to a non-coord word (NAVTEX terminator
+	// "NNN", message "END", etc.) must still be returned. The trailing
+	// letters can't themselves form a coordinate, so the strict
+	// letter-glue check is too aggressive in this shape.
+	cases := []findCase{
+		{
+			name:  "navtex_terminator_NNN",
+			input: "124-50-00ENNN",
+			want:  []string{"124-50-00E"},
+		},
+		// Counter-case: a minimal coord "3 N" glued to "M" (3 NM = 3
+		// nautical miles) must keep being rejected — the candidate has
+		// no min/sec to anchor it as a real coord.
+		{
+			name:  "distance_nm_minimal",
+			input: "3 NM",
+			want:  nil,
+		},
+	}
+	for i := range cases {
+		cases[i].opts = []FindOption{RequireDirection()}
+	}
+	runFindCases(t, cases)
+}
+
 func TestCoordRegexSourceEmbeddable(t *testing.T) {
 	// CoordRegexSource() output must be safe to embed inside a user-defined
 	// named group: it must not contain capture-group syntax of its own.

--- a/geoc.go
+++ b/geoc.go
@@ -382,8 +382,13 @@ func (cg *coordGroups) getFormatClass() formatClass {
 // named-group version used by ParseCoord/ParsePoint) reuse these so the two
 // stay structurally in sync.
 const (
-	rxNum    = `\d+(?:[\.,]\d+)?`
-	rxDegSep = `\s*[-°\.]?\s*`
+	rxNum = `\d+(?:[\.,]\d+)?`
+	// rxDegSep allows a newline only when bridged by an explicit "-"/"°"/"."
+	// separator (intra-coord linebreak like "38-\n34.2N"). Without such a
+	// separator, only horizontal whitespace is allowed — otherwise FindCoords
+	// would greedily eat "\n" between an unrelated number and the next line's
+	// real coordinate (e.g. "BR-117\n55-54.0N").
+	rxDegSep = `[^\S\n]*(?:[-°\.][^\S\n]*\n?[^\S\n]*)?`
 	rxMinSep = `\s*[-'\.]?\s*`
 	rxSecSep = `\s*[ "]?\s*`
 )


### PR DESCRIPTION
Closes #12.

## Summary

Three NAVTEX-driven shapes in `FindCoords` that currently leak knowledge
back into the consumer:

- `1 N.M.` (one nautical mile) was mismatched as `1°N` because the
  letter-glue check looked at exactly one byte after the direction
  letter and a `.` is not a letter.
- `BR-117\n55-54.0N` lost the real coord on the next line: the regex
  greedily ate `\n` between deg `117` and the next line's components,
  produced an oversized candidate that failed the latitude range, and
  by then the scan had already advanced past `55-54.0N`.
- `124-50-00ENNN` (NAVTEX message terminator glued to a coord) was
  dropped because the next byte after `E` is `N`, a letter.

## Fixes

| Fix | Where |
|---|---|
| `unitSuffixRE` look-ahead after loc letter | [find.go](find.go) |
| Manual scan loop with one-byte backtracking on drop | [find.go](find.go) |
| `rxDegSep` allows `\n` only when bridged by `-`/`°`/`.` | [geoc.go](geoc.go) |
| Letter-glue relaxed for full-DMS candidates whose trail has no digits | [find.go](find.go) |

## Test plan

- [x] Existing `TestFindCoords*` tests stay green.
- [x] New `TestFindCoordsUnitSuffixRejected`, `TestFindCoordsNoCrossLineGreedy`, `TestFindCoordsGluedToTerminator` cover the three cases.
- [x] `ParseCoord` / `ParsePoint` tests untouched.
- [x] `go test -race ./...` green.

## CHANGELOG

Entry staged under `## [v0.3.2] — unreleased`. The release-commit on
`main` will fill in the date when the tag is cut.

## Out of scope

`46-20.0NR142-2.0E` (OCR-glued pair through stray `R`) — would
re-introduce the `1 N.M.` class of false positives. Tracked separately
if ever needed (would need an explicit `Lenient()` opt-in).