### PR TITLE
fix: FindCoords resilient to inline-prefix and OCR-glue noise

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## [v0.3.3] — unreleased
+
+### Fixed
+
+- `FindCoords` now recovers the real coordinate when a numeric prefix is
+  glued to it by a space, e.g. `235 43-18.0N` returns `43-18.0N` instead of
+  the truncated `35 43-18.0N`. Backtracking on a failed candidate now skips
+  past the first whitespace inside the consumed span (same shape as the
+  v0.3.2 cross-line `\n` recovery, generalized).
+- `FindCoords` accepts a coordinate followed by a single non-direction
+  letter that is itself followed (optionally after whitespace) by a digit —
+  the fingerprint of an OCR glitch wedged between two adjacent coords. So
+  `46-20.0NR142-2.0E` now returns both `46-20.0N` and `142-2.0E`. Existing
+  unit / adjacent-direction / multi-letter-word rejections are preserved.
+
 ## [v0.3.2] by 2026-04-30
 
 ### Fixed

--- a/find.go
+++ b/find.go
@@ -119,7 +119,16 @@ func FindCoords(s string, opts ...FindOption) []Match {
 
 		coord, err := cg.getCoord()
 		if err != nil {
-			pos = idx[0] + 1
+			// Backtrack past the first whitespace inside the consumed
+			// candidate so a noise prefix glued to a coord by a space
+			// ("235 43-18.0N") doesn't trap us on a still-valid sub-
+			// candidate ("35 43-18.0N"). Same shape as the cross-line
+			// "BR-117\n55-54.0N" recovery, generalized.
+			if next := firstSpacePast(s, idx[0], idx[1]); next > 0 {
+				pos = next
+			} else {
+				pos = idx[0] + 1
+			}
 			continue
 		}
 
@@ -173,6 +182,12 @@ func acceptLetterGlue(s string, locEnd int, cg *coordGroups) bool {
 	if !isASCIILetter(rest[0]) {
 		return true
 	}
+	// OCR-glue: a single non-direction letter wedged between two adjacent
+	// coordinates ("46-20.0NR142-2.0E"). The next regex pass will pick up
+	// the second coord; here we just accept the current one.
+	if !isDirectionLetter(rest[0]) && isOCRGluePrefix(rest) {
+		return true
+	}
 	// Trailing letter glue. Keep the candidate only if it has full DMS
 	// structure (deg+min+sec) AND the trailing alphanumeric run contains
 	// no digits — i.e. it's a word, not another glued coord.
@@ -193,6 +208,45 @@ func acceptLetterGlue(s string, locEnd int, cg *coordGroups) bool {
 
 func isASCIILetter(b byte) bool {
 	return (b >= 'a' && b <= 'z') || (b >= 'A' && b <= 'Z')
+}
+
+func isDirectionLetter(b byte) bool {
+	switch b {
+	case 'N', 'S', 'E', 'W', 'n', 's', 'e', 'w':
+		return true
+	}
+	return false
+}
+
+// isOCRGluePrefix reports whether rest looks like an OCR-induced single
+// letter wedged between two coordinates: one ASCII letter, optionally
+// followed by horizontal whitespace, then an ASCII digit. Two consecutive
+// letters disqualify it (that's a word, not a glue artifact).
+func isOCRGluePrefix(rest string) bool {
+	if len(rest) < 2 || !isASCIILetter(rest[0]) {
+		return false
+	}
+	if isASCIILetter(rest[1]) {
+		return false
+	}
+	i := 1
+	for i < len(rest) && (rest[i] == ' ' || rest[i] == '\t') {
+		i++
+	}
+	return i < len(rest) && rest[i] >= '0' && rest[i] <= '9'
+}
+
+// firstSpacePast returns the byte position right after the first ASCII
+// whitespace inside s[start:end], or -1 if none. Used to recover from
+// candidates whose numeric prefix made the whole span fail range checks
+// ("235 43-18.0N" → restart at "43-18.0N", not "35 43-18.0N").
+func firstSpacePast(s string, start, end int) int {
+	for i := start; i < end; i++ {
+		if isASCIISpace(s[i]) {
+			return i + 1
+		}
+	}
+	return -1
 }
 
 // trimMatchSpan returns [start, end] adjusted to exclude ASCII whitespace

--- a/find_test.go
+++ b/find_test.go
@@ -292,6 +292,126 @@ func TestFindCoordsGluedToTerminator(t *testing.T) {
 	runFindCases(t, cases)
 }
 
+func TestFindCoordsInlineBacktrack(t *testing.T) {
+	// A purely numeric prefix glued to a real coordinate by a space made
+	// FindCoords backtrack only one byte after the out-of-range deg failed,
+	// landing on a still-valid sub-candidate ("235 43-18.0N" → "35 43-18.0N").
+	// Backtracking past the first whitespace inside the consumed span
+	// recovers the real coord.
+	cases := []findCase{
+		{
+			name:  "numeric_prefix_single",
+			input: "235 43-18.0N",
+			want:  []string{"43-18.0N"},
+		},
+		{
+			name:  "numeric_prefix_with_label",
+			input: "NO 235 43-18.0N",
+			want:  []string{"43-18.0N"},
+		},
+		{
+			name:  "numeric_prefix_pair",
+			input: "999 60-10.3N 028-45.7E",
+			want:  []string{"60-10.3N", "028-45.7E"},
+		},
+		{
+			name:  "four_digit_prefix",
+			input: "1234 89-59.9N",
+			want:  []string{"89-59.9N"},
+		},
+		{
+			name:  "real_navtex_area_line",
+			input: "A. NO 235 43-18.0N 047-47.6E 43-26.0N 047-47.6E",
+			want:  []string{"43-18.0N", "047-47.6E", "43-26.0N", "047-47.6E"},
+		},
+		// Counter-cases: must not break v0.3.2 behavior.
+		{
+			name:  "cross_line_zone_then_pair",
+			input: "BR-117\n55-54.0N 019-03.0E",
+			want:  []string{"55-54.0N", "019-03.0E"},
+		},
+		{
+			name:  "adjacent_valid_pair",
+			input: "55-54.0N 12-30.0N",
+			want:  []string{"55-54.0N", "12-30.0N"},
+		},
+		{
+			name:  "no_direction_no_match",
+			input: "10 20",
+			want:  nil,
+		},
+	}
+	for i := range cases {
+		cases[i].opts = []FindOption{RequireDirection()}
+	}
+	runFindCases(t, cases)
+}
+
+func TestFindCoordsOCRGlue(t *testing.T) {
+	// OCR sometimes wedges a single non-direction letter between two
+	// adjacent coordinates ("46-20.0NR142-2.0E"). v0.3.2's letter-glue
+	// check rejected such candidates; v0.3.3 accepts them when the trailing
+	// letter is followed (optionally after whitespace) by a digit.
+	cases := []findCase{
+		{
+			name:  "letter_then_digit_no_space",
+			input: "46-20.0NR142-2.0E",
+			want:  []string{"46-20.0N", "142-2.0E"},
+		},
+		{
+			name:  "letter_then_digit_q",
+			input: "30-15.0NQ140-30.0E",
+			want:  []string{"30-15.0N", "140-30.0E"},
+		},
+		{
+			name:  "letter_space_then_digit",
+			input: "30-15.0NX 140-30.0E",
+			want:  []string{"30-15.0N", "140-30.0E"},
+		},
+		// Counter-cases: must keep being rejected.
+		{
+			name:  "unit_with_dotted_M",
+			input: "1 N.M.",
+			want:  nil,
+		},
+		{
+			name:  "minimal_with_M",
+			input: "30NM",
+			want:  nil,
+		},
+		{
+			name:  "minimal_with_adjacent_direction",
+			input: "30NS",
+			want:  nil,
+		},
+		{
+			name:  "minimal_with_lone_letter",
+			input: "30NX",
+			want:  nil,
+		},
+		{
+			name:  "minimal_with_two_letters_then_digit",
+			input: "30NXY12",
+			want:  nil,
+		},
+		// Already worked in v0.3.2; lock it in.
+		{
+			name:  "navtex_terminator_NNN",
+			input: "124-50-00ENNN",
+			want:  []string{"124-50-00E"},
+		},
+		{
+			name:  "minimal_with_terminator_word",
+			input: "30N END",
+			want:  []string{"30N"},
+		},
+	}
+	for i := range cases {
+		cases[i].opts = []FindOption{RequireDirection()}
+	}
+	runFindCases(t, cases)
+}
+
 func TestCoordRegexSourceEmbeddable(t *testing.T) {
 	// CoordRegexSource() output must be safe to embed inside a user-defined
 	// named group: it must not contain capture-group syntax of its own.


### PR DESCRIPTION
Closes #14.

Two complementary noise-tolerance fixes in `FindCoords`:

**Case A — inline backtracking past out-of-range numeric prefix**
- `"235 43-18.0N"` → `["43-18.0N"]` (was `"35 43-18.0N"`)
- Same mechanism as v0.3.2 cross-line (`\n`) backtracking, generalized
  to "first whitespace" inside the consumed candidate.

**Case B — OCR-glue (single letter between two coords)**
- `"46-20.0NR142-2.0E"` → `["46-20.0N", "142-2.0E"]`
- Letter-glue check now accepts when the trailing letter is followed
  immediately (or after whitespace) by a digit. Existing unit-suffix,
  adjacent-direction and multi-letter-word rejections preserved.

## Tests
Added `TestFindCoordsInlineBacktrack` and `TestFindCoordsOCRGlue`. All
v0.3.2 positive/negative cases still pass (cross-line, terminator,
unit-suffix, adjacent direction, lone letter, two-letters-then-digit).

## Reviewer checklist
- [x] All v0.3.2 positive tests still green.
- [x] Cross-line `BR-117\n55-54.0N` still returns `55-54.0N`.
- [x] All Case A inline-prefix cases green.
- [x] All Case B OCR-glue cases green.
- [x] Counter-cases (`1 N.M.`, `30NM`, `30NS`, `30NX`, `30NXY12`) still empty.
- [x] Adjacent valid coords (`55-54.0N 12-30.0N`) not falsely swallowed.