### PR TITLE
fix: FindCoords/ParseCoord OCR resilience — italian DMS, trailing dot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,26 @@
 # Changelog
 
+## [v0.3.4] by 2026-05-05
+
+### Fixed
+
+- `ParseCoord`/`FindCoords` now accept italian-NAVTEX OCR output where the
+  fractional part of minutes is written as 3 digits without a decimal point
+  ("44 33 367N" really meaning 44° 33.367′ N). The shape — space-separated
+  deg/min/sec where sec is exactly 3 digits with no decimal — is now
+  reinterpreted as `min.frac`, so previously rejected inputs (sec ≥ 60) parse
+  correctly and `FindCoords` no longer falls back to noise sub-candidates
+  ("44 33 367N" used to surface as just `67N` via the v0.3.3 inline backtrack).
+
+### Changed
+
+- **Behavior change** for `<deg> <mm> <ddd>[NSEW]` shape with sec value < 60.
+  Previously interpreted as classical DMS (e.g. `44 33 048N` → 44° 33′ 48″ ≈
+  44.5633°); now interpreted as italian min.frac (44° 33.048′ ≈ 44.5508°).
+  The 3-digit no-decimal sec field with pure-space separators is a reliable
+  fingerprint of the italian format; classical DMS keeps working with
+  hyphen/`°`/`:` separators or a decimal in the sec field.
+
 ## [v0.3.3] by 2026-05-01
 
 ### Fixed

--- a/find.go
+++ b/find.go
@@ -109,6 +109,7 @@ func FindCoords(s string, opts ...FindOption) []Match {
 		}
 
 		cg, _ := coordGroupsFromMatch(groups, subNames)
+		cg.normalizeItalianMinFrac()
 		cg.normalizeDotDMS()
 		cg.normalizeCompact()
 

--- a/find_test.go
+++ b/find_test.go
@@ -412,6 +412,107 @@ func TestFindCoordsOCRGlue(t *testing.T) {
 	runFindCases(t, cases)
 }
 
+func TestFindCoordsItalianBadDec(t *testing.T) {
+	// Italian NAVTEX OCR omits the decimal point in the fractional part of
+	// minutes: "44 33 367N" really means "44° 33.367' N". The shape is
+	// space-separated deg/min/sec where sec is exactly 3 digits without a
+	// decimal — distinct from classical DMS.
+	cases := []findCase{
+		{
+			name:  "frac_over_60_pure",
+			input: "44 33 367N",
+			want:  []string{"44 33 367N"},
+		},
+		{
+			name:  "frac_under_60_with_pad",
+			input: "44 38 008N",
+			want:  []string{"44 38 008N"},
+		},
+		{
+			name:  "ambiguous_under_60",
+			input: "44 33 048N",
+			want:  []string{"44 33 048N"},
+		},
+		{
+			name:  "lat_lon_pair_mixed_styles",
+			input: "44 33 048N 012 33.155E",
+			want:  []string{"44 33 048N", "012 33.155E"},
+		},
+		{
+			name:  "real_navtex_block",
+			input: "44 33 367N 012 33.853E\n44 38 617N 012 28.754E",
+			want: []string{
+				"44 33 367N", "012 33.853E",
+				"44 38 617N", "012 28.754E",
+			},
+		},
+		// Counter-cases: classical DMS must keep its meaning.
+		{
+			name:  "classical_dms_two_digit_sec",
+			input: "44 33 12N",
+			want:  []string{"44 33 12N"},
+		},
+		{
+			name:  "classical_dms_with_decimal_sec",
+			input: "44 33-12.0N",
+			want:  []string{"44 33-12.0N"},
+		},
+		{
+			name:  "classical_dms_hyphens",
+			input: "48-33-27N",
+			want:  []string{"48-33-27N"},
+		},
+	}
+	for i := range cases {
+		cases[i].opts = []FindOption{RequireDirection()}
+	}
+	runFindCases(t, cases)
+}
+
+func TestFindCoordsTrailingDot(t *testing.T) {
+	// A dot directly before a direction letter ("52.E") happens when OCR
+	// drops the digit after the decimal point. The trailing dot is treated
+	// as a deg/coord-letter separator, so the candidate is recognized as
+	// 52°E without any extra normalization.
+	cases := []findCase{
+		{
+			name:  "trailing_dot_lon",
+			input: "52.E",
+			want:  []string{"52.E"},
+		},
+		{
+			name:  "trailing_dot_lat",
+			input: "12.N",
+			want:  []string{"12.N"},
+		},
+		{
+			name:  "pair_trailing_dot",
+			input: "12.N 045.E",
+			want:  []string{"12.N", "045.E"},
+		},
+		{
+			name:  "trailing_dot_after_min",
+			input: "012-30.N",
+			want:  []string{"012-30.N"},
+		},
+		// Counter-cases: well-formed coords must keep matching unchanged.
+		{
+			name:  "no_dot",
+			input: "52E",
+			want:  []string{"52E"},
+		},
+		{
+			name:  "full_decimal",
+			input: "52.0E",
+			want:  []string{"52.0E"},
+		},
+	}
+	for i := range cases {
+		cases[i].opts = []FindOption{RequireDirection()}
+	}
+	runFindCases(t, cases)
+}
+
 func TestCoordRegexSourceEmbeddable(t *testing.T) {
 	// CoordRegexSource() output must be safe to embed inside a user-defined
 	// named group: it must not contain capture-group syntax of its own.

--- a/geoc.go
+++ b/geoc.go
@@ -334,6 +334,42 @@ func (cg *coordGroups) normalizeCompact() {
 	}
 }
 
+// normalizeItalianMinFrac handles space-separated forms where the fractional
+// part of minutes is written as 3 digits without a decimal point — common in
+// italian NAVTEX OCR output ("44 33 367N" meaning "44° 33.367' N"). The shape
+// is `<deg> <min> <minFrac3>[NSEW]`, with both separators being plain
+// whitespace and the would-be sec field consisting of exactly 3 ASCII digits.
+// Classical DMS uses "-"/"°"/":" or has a decimal in the sec field, so a
+// pure-space separator with a 3-digit no-decimal trailer is a reliable
+// fingerprint. Without this normalization the candidate is interpreted as
+// DMS and then either rejected (sec ≥ 60, e.g. "367") or — worse — silently
+// produces wrong coordinates (sec < 60, e.g. "048" parsed as 48 seconds).
+func (cg *coordGroups) normalizeItalianMinFrac() {
+	if cg.loc == "" || cg.sec == "" || cg.min == "" {
+		return
+	}
+	if cg.sep.deg != " " || cg.sep.min != " " {
+		return
+	}
+	if len(cg.sec) != 3 {
+		return
+	}
+	if strings.ContainsAny(cg.sec, ".,") {
+		return
+	}
+	for i := 0; i < len(cg.sec); i++ {
+		if cg.sec[i] < '0' || cg.sec[i] > '9' {
+			return
+		}
+	}
+	if strings.ContainsAny(cg.min, ".,") {
+		return
+	}
+	cg.min = cg.min + "." + cg.sec
+	cg.sec = ""
+	cg.sep.min = ""
+}
+
 // normalizeDotDMS handles forms like "70.19.4N" and "018.07.5E".
 // Regex can initially parse them as deg=70.19, min=4. This method
 // converts such shape into regular DMS groups: deg=70, min=19, sec=4.
@@ -467,6 +503,7 @@ func newCoordGroups(cs string) (coordGroups, error) {
 		return cg, fmt.Errorf("%w: extra characters detected", ErrInvalidString)
 	}
 
+	cg.normalizeItalianMinFrac()
 	cg.normalizeDotDMS()
 	cg.normalizeCompact()
 	return cg, nil
@@ -507,6 +544,8 @@ func newPointGroups(cs string) (coordGroups, coordGroups, error) {
 		cgLon.sgn = ""
 	}
 
+	cgLat.normalizeItalianMinFrac()
+	cgLon.normalizeItalianMinFrac()
 	cgLat.normalizeDotDMS()
 	cgLon.normalizeDotDMS()
 	cgLat.normalizeCompact()

--- a/geoc_test.go
+++ b/geoc_test.go
@@ -360,6 +360,16 @@ func TestParseCoordPositive(t *testing.T) {
 		{`90S`, -90, LocLat},
 		{`180E`, 180, LocLon},
 		{`180W`, -180, LocLon},
+
+		// Italian min.frac (Case A): space-separated <deg> <min> <minFrac3>[NSEW]
+		{`44 33 367N`, 44.556117, LocLat}, // 44° 33.367' N
+		{`44 38 008N`, 44.633467, LocLat}, // 44° 38.008' N (NOT DMS sec=8)
+		{`44 33 048N`, 44.5508, LocLat},   // 44° 33.048' N (NOT DMS sec=48)
+		{`012 33.853E`, 12.564217, LocLon},
+
+		// Trailing dot before direction letter (Case C): "52.E" → 52.0°E
+		{`52.E`, 52, LocLon},
+		{`012-30.N`, 12.5, LocLat},
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
Follow-up #3 from `docs/geoc_find_followup_3.md`. Two of the three planned cases land in geoc; the third (LON overflow recovery) was deliberately left out — see below.

## Case A — italian DMS without decimal point in fractional minutes

Italian-NAVTEX OCR omits the decimal between integer and fractional minutes:
`44 33 367N` really means `44° 33.367′ N`, written as `<deg> <min> <minFrac3>[NSEW]` with pure-space separators and a 3-digit no-decimal trailer.

Before this PR `ParseCoord("44 33 367N")` failed with `out of range: seconds` and `FindCoords` surfaced just `67N` via the v0.3.3 inline backtrack. Now both return `44.5561°` correctly.

New `normalizeItalianMinFrac` lives next to `normalizeDotDMS`/`normalizeCompact` and is invoked from the same three call sites (`newCoordGroups`, `newPointGroups`, `FindCoords`).

**Behavior change.** `<deg> <mm> <ddd>[NSEW]` with sec value < 60 (e.g. `44 33 048N`) used to parse as classical DMS `44° 33′ 48″ ≈ 44.5633°`; it now parses as italian min.frac `44° 33.048′ ≈ 44.5508°`. The 3-digit no-decimal trailer with pure-space separators is a reliable fingerprint — classical DMS keeps working with hyphen/`°`/`:` separators or a decimal in the sec field.

## Case C — trailing dot before direction letter

`52.E` (a `52.0E` where OCR dropped the trailing zero) is already handled correctly by the existing regex: the dot is consumed as a deg/letter separator and the candidate parses as `52°E`. No code change needed; this PR only adds tests to lock the behavior in.

## Case B — LON overflow recovery (deliberately not included)

The plan also asked geoc to absorb `nxex.fixLonOverflow` (`228-44E` → `28-44E` when `deg > 180` and direction is E/W). After implementing it and reviewing, dropped it: at the geoc layer there is no general way to tell an OCR-inserted leading digit from a glued message-number or channel-id. Cutting the first digit is one guess among several. Cases A and C have structural fingerprints (italian: 3-digit no-decimal sec with space separators; trailing-dot: `\d\.[NSEW]`); Case B has only `deg > 180`, which is just "invalid input" from geoc's perspective.

`nxex` keeps `fixLonOverflow` — that layer has the domain knowledge to make the call.

## Tests

- `TestFindCoordsItalianBadDec` (find_test.go) — italian min.frac shapes, classical-DMS counter-cases, mixed-format pair, real-NAVTEX block.
- `TestFindCoordsTrailingDot` (find_test.go) — trailing-dot lock-in.
- `TestParseCoordPositive` (geoc_test.go) — italian min.frac + trailing-dot rows added.

All existing tests pass unchanged.

## Checklist

- [x] Case A: `44 33 367N` returns coord with `min=33.367` (not rejected, not noise).
- [x] Case A counter: `44 33 12N` stays classical DMS (deg=44, min=33, sec=12).
- [x] Case A counter: `44 33-12.0N` stays classical DMS (hyphen separator).
- [x] Case C: `52.E` parsed as `52.0°E`.
- [x] Case C counter: `52E` and `52.0E` unchanged.
- [x] CHANGELOG.md updated with `[v0.3.4]` entry including the behavior-change note.

🤖 Generated with [Claude Code](https://claude.com/claude-code)