### PR TITLE
Fix NAVTEX coordinate parsing edge cases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## [v0.3.5] by 2026-05-11
+
+### Fixed
+
+- `FindCoords` no longer reports date-list fragments before month
+  abbreviations as coordinates, e.g. `24 25 28 NOV` is not returned as
+  `24 25 28 N`.
+- `FindCoords` now preserves the full longitude when a latitude ending in
+  `N`/`S` is followed by a glued hyphen separator, e.g.
+  `41 55.00 N-032 08.00 E` returns `032 08.00 E` instead of the truncated
+  `08.00 E`.
+
 ## [v0.3.4] by 2026-05-05
 
 ### Fixed

--- a/find.go
+++ b/find.go
@@ -120,6 +120,10 @@ func FindCoords(s string, opts ...FindOption) []Match {
 
 		coord, err := cg.getCoord()
 		if err != nil {
+			if isLatLonHyphenSeparator(s, idx[0]) {
+				pos = idx[0] + 1
+				continue
+			}
 			// Backtrack past the first whitespace inside the consumed
 			// candidate so a noise prefix glued to a coord by a space
 			// ("235 43-18.0N") doesn't trap us on a still-valid sub-
@@ -183,6 +187,9 @@ func acceptLetterGlue(s string, locEnd int, cg *coordGroups) bool {
 	if !isASCIILetter(rest[0]) {
 		return true
 	}
+	if isMonthGlue(s, locEnd) {
+		return false
+	}
 	// OCR-glue: a single non-direction letter wedged between two adjacent
 	// coordinates ("46-20.0NR142-2.0E"). The next regex pass will pick up
 	// the second coord; here we just accept the current one.
@@ -205,6 +212,38 @@ func acceptLetterGlue(s string, locEnd int, cg *coordGroups) bool {
 		}
 	}
 	return true
+}
+
+func isMonthGlue(s string, locEnd int) bool {
+	if locEnd <= 0 {
+		return false
+	}
+	start := locEnd - 1
+	end := locEnd
+	for end < len(s) && isASCIILetter(s[end]) {
+		end++
+	}
+	if end-start != 3 {
+		return false
+	}
+	month := upperASCII(s[start:end])
+	switch month {
+	case "JAN", "FEB", "MAR", "APR", "MAY", "JUN", "JUL", "AUG", "SEP", "OCT", "NOV", "DEC":
+		return true
+	}
+	return false
+}
+
+func upperASCII(s string) string {
+	var b [3]byte
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		if c >= 'a' && c <= 'z' {
+			c -= 'a' - 'A'
+		}
+		b[i] = c
+	}
+	return string(b[:len(s)])
 }
 
 func isASCIILetter(b byte) bool {
@@ -235,6 +274,20 @@ func isOCRGluePrefix(rest string) bool {
 		i++
 	}
 	return i < len(rest) && rest[i] >= '0' && rest[i] <= '9'
+}
+
+func isLatLonHyphenSeparator(s string, hyphen int) bool {
+	if hyphen <= 0 || hyphen+1 >= len(s) || s[hyphen] != '-' {
+		return false
+	}
+	if s[hyphen+1] < '0' || s[hyphen+1] > '9' {
+		return false
+	}
+	prev := hyphen - 1
+	for prev >= 0 && (s[prev] == ' ' || s[prev] == '\t') {
+		prev--
+	}
+	return prev >= 0 && (s[prev] == 'N' || s[prev] == 'S')
 }
 
 // firstSpacePast returns the byte position right after the first ASCII

--- a/find_test.go
+++ b/find_test.go
@@ -91,6 +91,12 @@ func TestFindCoordsPositive(t *testing.T) {
 			want:  []string{"39 27 25.55N", "009 39 25E"},
 		},
 		{
+			name:  "navtex_pair_with_glued_dash_separator",
+			input: "41 55.00 N-032 08.00 E",
+			opts:  []FindOption{RequireDirection()},
+			want:  []string{"41 55.00 N", "032 08.00 E"},
+		},
+		{
 			name:  "pair_with_comma_separator",
 			input: "lat 39 27N, lon 40 30E end",
 			opts:  []FindOption{RequireDirection()},
@@ -284,6 +290,38 @@ func TestFindCoordsGluedToTerminator(t *testing.T) {
 			name:  "distance_nm_minimal",
 			input: "3 NM",
 			want:  nil,
+		},
+	}
+	for i := range cases {
+		cases[i].opts = []FindOption{RequireDirection()}
+	}
+	runFindCases(t, cases)
+}
+
+func TestFindCoordsDateMonthGlueRejected(t *testing.T) {
+	// Date lists before a month abbreviation can look exactly like DMS;
+	// the direction letter is just the first letter of the month.
+	cases := []findCase{
+		{
+			name:  "november_date_list",
+			input: "24 25 28 NOV 25 FROM 0600",
+			want:  nil,
+		},
+		{
+			name:  "september_date_list",
+			input: "12 14 16 SEP 25",
+			want:  nil,
+		},
+		// Counter-cases: non-month terminators remain accepted.
+		{
+			name:  "navtex_terminator_NNN",
+			input: "124-50-00ENNN",
+			want:  []string{"124-50-00E"},
+		},
+		{
+			name:  "message_word",
+			input: "124-50-00EAREA",
+			want:  []string{"124-50-00E"},
 		},
 	}
 	for i := range cases {


### PR DESCRIPTION
## Summary
- reject DMS-shaped date-list fragments glued to month abbreviations in FindCoords
- recover full longitude after glued N/S hyphen separators such as `41 55.00 N-032 08.00 E`
- document v0.3.5 changes in CHANGELOG

## Tests
- `go test ./...`

Closes #18
Closes #19