### PR TITLE
feat: parse compact MinDec coordinates (DDMM.fffN / DDDMM.fffE)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## [unreleased]
+
+### Fixed
+
+- `ParseCoord`/`FindCoords` now recognize compact MinDec inputs where degrees
+  and decimal-minutes are written as a single concatenated number with no
+  separator — common in NAVTEX traffic, e.g. `3630.055N` (36° 30.055′ N) or
+  `01202.598E` (12° 02.598′ E). Without this the shape was parsed as a single
+  degDec value (`3630.055`) and rejected as out-of-range. The rewrite is
+  triggered narrowly: requires a direction letter, no deg-min separator,
+  exactly 4 (lat) or 5 (lon) integer digits, a decimal fraction, and the
+  implied deg/min parts must satisfy axis bounds and `min < 60`.
+
 ## [v0.3.5] by 2026-05-11
 
 ### Fixed

--- a/geoc.go
+++ b/geoc.go
@@ -370,6 +370,57 @@ func (cg *coordGroups) normalizeItalianMinFrac() {
 	cg.sep.min = ""
 }
 
+// compactMinDecLatRegExp / compactMinDecLonRegExp match concatenated MinDec
+// integer parts: 2-digit deg + 2-digit min for N/S, 3-digit deg + 2-digit min
+// for E/W. The deg group is range-checked (≤90 / ≤180) and the min group is
+// constrained to `[0-5]\d` so the trailing minutes stay < 60.
+var (
+	compactMinDecLatRegExp = regexp.MustCompile(`^(\d{2})([0-5]\d)\.(\d+)$`)
+	compactMinDecLonRegExp = regexp.MustCompile(`^(\d{3})([0-5]\d)\.(\d+)$`)
+)
+
+// normalizeCompactMinDec handles compact MinDec inputs where degrees and
+// decimal minutes are written as a single concatenated number with no
+// separator, e.g. "3630.055N" meaning 36° 30.055' N, or "01202.598E" meaning
+// 12° 02.598' E. This is the MinDec analogue of the compact DMS form
+// (`DDMMSS`) that normalizeCompact already handles. The regex parses such
+// inputs as a single deg group with a decimal fraction and an empty min/sec,
+// which the degDec branch then rejects as out-of-range (>90 / >180).
+//
+// Trigger is intentionally narrow:
+//   - direction letter is present;
+//   - no deg-min separator was consumed (degDec parse path);
+//   - both min and sec are empty;
+//   - deg matches `^\d{4,5}\.\d+$` — 4 integer digits for N/S or 5 for E/W;
+//   - splitting deg into a leading deg part (2 digits for N/S, 3 for E/W)
+//     and a trailing `\d{2}\.\d+` minutes part keeps the deg part in axis
+//     bounds (≤90 lat, ≤180 lon) and the minutes part < 60.
+func (cg *coordGroups) normalizeCompactMinDec() {
+	if cg.loc == "" || cg.min != "" || cg.sec != "" || cg.sep.deg != "" {
+		return
+	}
+	var re *regexp.Regexp
+	var degMax int
+	switch cg.loc {
+	case "N", "S":
+		re, degMax = compactMinDecLatRegExp, 90
+	case "E", "W":
+		re, degMax = compactMinDecLonRegExp, 180
+	default:
+		return
+	}
+	m := re.FindStringSubmatch(cg.deg)
+	if m == nil {
+		return
+	}
+	degVal, err := strconv.Atoi(m[1])
+	if err != nil || degVal > degMax {
+		return
+	}
+	cg.deg = m[1]
+	cg.min = m[2] + "." + m[3]
+}
+
 // normalizeDotDMS handles forms like "70.19.4N" and "018.07.5E".
 // Regex can initially parse them as deg=70.19, min=4. This method
 // converts such shape into regular DMS groups: deg=70, min=19, sec=4.
@@ -505,6 +556,7 @@ func newCoordGroups(cs string) (coordGroups, error) {
 
 	cg.normalizeItalianMinFrac()
 	cg.normalizeDotDMS()
+	cg.normalizeCompactMinDec()
 	cg.normalizeCompact()
 	return cg, nil
 }
@@ -548,6 +600,8 @@ func newPointGroups(cs string) (coordGroups, coordGroups, error) {
 	cgLon.normalizeItalianMinFrac()
 	cgLat.normalizeDotDMS()
 	cgLon.normalizeDotDMS()
+	cgLat.normalizeCompactMinDec()
+	cgLon.normalizeCompactMinDec()
 	cgLat.normalizeCompact()
 	cgLon.normalizeCompact()
 	return cgLat, cgLon, nil

--- a/geoc_test.go
+++ b/geoc_test.go
@@ -367,6 +367,16 @@ func TestParseCoordPositive(t *testing.T) {
 		{`44 33 048N`, 44.5508, LocLat},   // 44° 33.048' N (NOT DMS sec=48)
 		{`012 33.853E`, 12.564217, LocLon},
 
+		// Compact MinDec: degrees and decimal-minutes glued together
+		{`3630.055N`, 36.500917, LocLat},   // 36° 30.055' N
+		{`01202.598E`, 12.043300, LocLon},  // 12° 02.598' E
+		{`3500.00N`, 35.0, LocLat},         // 35° 00.00' N
+		{`01500.00E`, 15.0, LocLon},        // 15° 00.00' E
+		{`3630.055S`, -36.500917, LocLat},  // S → negative
+		{`01202.598W`, -12.043300, LocLon}, // W → negative
+		// Must not collide with existing degDec inputs in range.
+		{`36.5N`, 36.5, LocLat},
+
 		// Trailing dot before direction letter (Case C): "52.E" → 52.0°E
 		{`52.E`, 52, LocLon},
 		{`012-30.N`, 12.5, LocLat},
@@ -397,6 +407,18 @@ func TestParseCoordNegative(t *testing.T) {
 		{`120-5760E`, ErrOutOfRange},
 		{`90-01N`, ErrOutOfRange},
 		{`180-01E`, ErrOutOfRange},
+		// Compact MinDec must not over-trigger: 3-digit integer + decimal
+		// stays degDec and gets rejected by axis range check (not silently
+		// rewritten as 3°65.5').
+		{`365.5N`, ErrOutOfRange},
+		// Compact MinDec with deg > 90 (lat) / > 180 (lon) is also out-of-range.
+		{`9130.0N`, ErrOutOfRange}, // 91° 30.0' N
+		// Minutes part ≥ 60 prevents the rewrite, so 3660.0N stays degDec
+		// and is rejected as out-of-range.
+		{`3660.0N`, ErrOutOfRange},
+		// Bare number without direction letter: not rewritten, falls through
+		// to plain DegDec out-of-range check.
+		{`3630.055`, ErrOutOfRange},
 		{`48"N`, ErrInvalidString},
 		{`48'N`, ErrInvalidString},
 		{`-48N`, ErrInvalidCoord},


### PR DESCRIPTION
## Summary

- Adds `normalizeCompactMinDec` that rewrites NAVTEX-style coordinates where the integer parts of degrees and decimal-minutes are concatenated without a separator (e.g. `3630.055N` → 36° 30.055′ N, `01202.598E` → 12° 02.598′ E).
- Previously such inputs were parsed as a single degDec value (e.g. `3630.055`) and rejected as out-of-range.
- Trigger is narrow on purpose: direction letter present, no deg-min separator, 4 (lat) or 5 (lon) integer digits, decimal fraction, implied deg/min parts within axis bounds and `min < 60`.

Closes #21

## Test plan

- [x] `go test ./...` — all green, including the new compact MinDec cases and over-trigger guards (`365.5N`, `9130.0N`, `3660.0N`, `3630.055`).
- [x] `golangci-lint run ./...` — clean.
- [x] `go vet ./...` / `gofmt -l .` — clean.