### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/o-kos/geoc/security/code-scanning/2](https://github.com/o-kos/geoc/security/code-scanning/2)

Add an explicit `permissions` block at the workflow root so it applies to all jobs (`test` and `lint`) without changing existing behavior. The safest minimal fix for this CI file is:

- `contents: read`

This matches checkout/read-only source access and satisfies CodeQL’s recommendation.  
Edit `.github/workflows/ci.yml` by inserting the `permissions` section after the `on:` block (before `jobs:`), preserving current job logic and steps. No imports, methods, or extra definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
