### PR TITLE
fix: FindCoords recognizes compact MinDec coordinates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## [v0.3.7] by 2026-05-20
+
+### Fixed
+
+- `FindCoords` now recognizes compact MinDec inputs (`DDMM.fffN` /
+  `DDDMM.fffE`) that `ParseCoord`/`ParsePoint` already accepted in v0.3.6.
+  The scan path in `find.go` was missing the `normalizeCompactMinDec` step,
+  so NAVTEX traffic with Malta-style compact coordinates (e.g.
+  `3630.055N 01202.598E`) returned no matches under `RequireDirection()`.
+  Closes #27.
+
 ## [v0.3.6] by 2026-05-20
 
 ### Fixed

--- a/find.go
+++ b/find.go
@@ -111,6 +111,7 @@ func FindCoords(s string, opts ...FindOption) []Match {
 		cg, _ := coordGroupsFromMatch(groups, subNames)
 		cg.normalizeItalianMinFrac()
 		cg.normalizeDotDMS()
+		cg.normalizeCompactMinDec()
 		cg.normalizeCompact()
 
 		if !acceptLetterGlue(s, idx[2*locGroupIndex+1], &cg) {

--- a/find_test.go
+++ b/find_test.go
@@ -551,6 +551,42 @@ func TestFindCoordsTrailingDot(t *testing.T) {
 	runFindCases(t, cases)
 }
 
+func TestFindCoordsCompactMinDec(t *testing.T) {
+	// Compact MinDec — degrees and decimal-minutes glued into a single
+	// number with no separator ("3630.055N" = 36° 30.055' N). ParseCoord /
+	// ParsePoint already accept this shape in v0.3.6; FindCoords was missing
+	// the normalizeCompactMinDec step on its scan path.
+	cases := []findCase{
+		{
+			name:  "lat_lon_pair",
+			input: "3630.055N 01202.598E",
+			want:  []string{"3630.055N", "01202.598E"},
+		},
+		{
+			name:  "multiple_pairs_newline",
+			input: "3630.439N 01859.313E\n3501.433N 02211.228E",
+			want: []string{
+				"3630.439N", "01859.313E",
+				"3501.433N", "02211.228E",
+			},
+		},
+		{
+			name:  "zero_pad_frac",
+			input: "3500.00N 01500.00E",
+			want:  []string{"3500.00N", "01500.00E"},
+		},
+		{
+			name:  "embedded_in_text",
+			input: "POSITION 3630.055N 01202.598E REPORTED",
+			want:  []string{"3630.055N", "01202.598E"},
+		},
+	}
+	for i := range cases {
+		cases[i].opts = []FindOption{RequireDirection()}
+	}
+	runFindCases(t, cases)
+}
+
 func TestCoordRegexSourceEmbeddable(t *testing.T) {
 	// CoordRegexSource() output must be safe to embed inside a user-defined
 	// named group: it must not contain capture-group syntax of its own.


### PR DESCRIPTION
## Summary

- `FindCoords` scan path in [find.go](find.go) was missing the `normalizeCompactMinDec` step, so `DDMM.fffN` / `DDDMM.fffE` shapes (e.g. `3630.055N 01202.598E`) found no matches under `RequireDirection()`, while `ParseCoord`/`ParsePoint` already handled them in v0.3.6.
- Inserted `cg.normalizeCompactMinDec()` between `normalizeDotDMS` and `normalizeCompact` to mirror the constructor order in `geoc.go` (`newPointGroups`, lines 562–565).
- Added `TestFindCoordsCompactMinDec` covering pair, multi-pair, zero-pad-frac and embedded-in-text cases from the issue.
- CHANGELOG entry for v0.3.7 included.

Closes #27.

## Test plan

- [x] `go test -race ./...` — all green locally
- [x] `golangci-lint run ./...` — clean
- [ ] CI green on Go 1.20 / 1.21 / 1.22 + lint job