### PR TITLE
fix: drop DMS candidates with a direction letter glued to a word

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## [unreleased]
+
+### Changed
+
+- `FindCoords` no longer accepts a fully specified DMS candidate whose
+  direction letter is glued to a trailing all-letter word. The letter is the
+  head of that word, not a coordinate's direction, so `59 1900 NAVIGATION`
+  (e.g. the end of a `0500 /59 1900` time interval) no longer yields a spurious
+  `59 1900 N`. geoc can't locally tell a borrowed word-initial letter from a
+  real NAVTEX terminator, so terminators are dropped too — `124-50-00ENNN` now
+  returns nothing instead of `124-50-00E`; stripping them is the consumer's
+  job. Direction letters followed by space/punctuation (`30N END`,
+  `5121.00 N ... E ENDS`) and OCR-glue bridges (`46-20.0NR142-2.0E`) are
+  unaffected. Closes #32.
+
 ## [v0.3.8] by 2026-05-23
 
 ### Added

--- a/find.go
+++ b/find.go
@@ -172,11 +172,11 @@ func FindCoords(s string, opts ...FindOption) []Match {
 //
 //   - Unit suffix (".M.", " MILE", "KM" etc.): always drops, since the
 //     direction letter is part of a distance token, not a coordinate.
-//   - Plain letter glue (e.g. "1NORTH", "3 NM"): drops minimal candidates
-//     (no min/sec) where the trailing word could be anything, but accepts
-//     fully-specified DMS candidates whose trailing letters can't form a
-//     coord on their own (NAVTEX terminator "NNN", message words like
-//     "END"/"AREA"). See TestFindCoordsGluedToTerminator.
+//   - Plain letter glue (e.g. "1NORTH", "3 NM", "59 1900 NAVIGATION"): drops
+//     the candidate, since a direction letter glued to letters is the head of
+//     a word, not a coordinate's direction. NAVTEX terminators are dropped too
+//     ("124-50-00ENNN" yields nothing); stripping them is the consumer's job.
+//     The OCR-glue bridge to an adjacent coord is the one kept exception.
 func acceptLetterGlue(s string, locEnd int, cg *coordGroups) bool {
 	if cg.loc == "" || locEnd < 0 || locEnd >= len(s) {
 		return true
@@ -197,22 +197,13 @@ func acceptLetterGlue(s string, locEnd int, cg *coordGroups) bool {
 	if !isDirectionLetter(rest[0]) && isOCRGluePrefix(rest) {
 		return true
 	}
-	// Trailing letter glue. Keep the candidate only if it has full DMS
-	// structure (deg+min+sec) AND the trailing alphanumeric run contains
-	// no digits — i.e. it's a word, not another glued coord.
-	if cg.sec == "" {
-		return false
-	}
-	for i := 0; i < len(rest); i++ {
-		c := rest[i]
-		if c >= '0' && c <= '9' {
-			return false
-		}
-		if !isASCIILetter(c) {
-			break
-		}
-	}
-	return true
+	// Trailing letter glue: a direction letter immediately followed by more
+	// letters belongs to that word, not to a coordinate ("59 1900 NAVIGATION"
+	// borrows the N from NAVIGATION). geoc can't locally tell a borrowed
+	// word-initial letter from a real NAVTEX terminator ("124-50-00ENNN" ->
+	// "124-50-00E") — the forms are identical — so it does not guess. Such
+	// candidates are dropped; stripping terminators is the consumer's job.
+	return false
 }
 
 func isMonthGlue(s string, locEnd int) bool {

--- a/find_test.go
+++ b/find_test.go
@@ -272,16 +272,29 @@ func TestFindCoordsNoCrossLineGreedy(t *testing.T) {
 	runFindCases(t, cases)
 }
 
-func TestFindCoordsGluedToTerminator(t *testing.T) {
-	// A fully-specified coord glued to a non-coord word (NAVTEX terminator
-	// "NNN", message "END", etc.) must still be returned. The trailing
-	// letters can't themselves form a coordinate, so the strict
-	// letter-glue check is too aggressive in this shape.
+func TestFindCoordsGluedToWordRejected(t *testing.T) {
+	// A direction letter immediately glued to an all-letter word is the head
+	// of that word, not a coordinate's direction. geoc can't locally tell a
+	// borrowed word-initial letter ("59 1900 N"avigation) from a real NAVTEX
+	// terminator ("124-50-00ENNN"), so it drops both — stripping terminators
+	// is the consumer's job.
 	cases := []findCase{
 		{
 			name:  "navtex_terminator_NNN",
 			input: "124-50-00ENNN",
-			want:  []string{"124-50-00E"},
+			want:  nil,
+		},
+		{
+			name:  "navtex_terminator_AREA",
+			input: "124-50-00EAREA",
+			want:  nil,
+		},
+		// The reported false positive: "59 1900" is the end of a time
+		// interval, the N is borrowed from NAVIGATION.
+		{
+			name:  "time_interval_glued_to_word",
+			input: "0500 /59 1900 NAVIGATION PROHIBITED",
+			want:  nil,
 		},
 		// Counter-case: a minimal coord "3 N" glued to "M" (3 NM = 3
 		// nautical miles) must keep being rejected — the candidate has
@@ -312,16 +325,17 @@ func TestFindCoordsDateMonthGlueRejected(t *testing.T) {
 			input: "12 14 16 SEP 25",
 			want:  nil,
 		},
-		// Counter-cases: non-month terminators remain accepted.
+		// Non-month terminators are dropped too: a direction letter glued
+		// to a word is never a coordinate.
 		{
 			name:  "navtex_terminator_NNN",
 			input: "124-50-00ENNN",
-			want:  []string{"124-50-00E"},
+			want:  nil,
 		},
 		{
 			name:  "message_word",
 			input: "124-50-00EAREA",
-			want:  []string{"124-50-00E"},
+			want:  nil,
 		},
 	}
 	for i := range cases {
@@ -432,11 +446,12 @@ func TestFindCoordsOCRGlue(t *testing.T) {
 			input: "30NXY12",
 			want:  nil,
 		},
-		// Already worked in v0.3.2; lock it in.
+		// A direction letter glued to a word (not an OCR bridge to a
+		// digit) is dropped: "124-50-00ENNN" yields nothing.
 		{
 			name:  "navtex_terminator_NNN",
 			input: "124-50-00ENNN",
-			want:  []string{"124-50-00E"},
+			want:  nil,
 		},
 		{
 			name:  "minimal_with_terminator_word",


### PR DESCRIPTION
## Summary

A fully specified DMS candidate whose direction letter is glued to a trailing
all-letter word is no longer accepted as a coordinate — the letter is the head
of that word, not a direction. `59 1900 NAVIGATION` (the end of a `0500 /59 1900`
time interval) stops yielding a spurious `59 1900 N`. geoc can't locally tell a
borrowed word-initial letter from a real NAVTEX terminator, so terminators are
dropped too (`124-50-00ENNN` now returns nothing); stripping them is the
consumer's job. The fix collapses the "full-DMS + word → keep" branch of
`acceptLetterGlue` to a drop. Space/punctuation after the letter and OCR-glue
bridges are unaffected.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test -race -coverprofile=coverage.out ./...` — pass, coverage 96.4%
- [x] `golangci-lint run` — clean
- [x] Updated tests: `TestFindCoordsGluedToTerminator` → `TestFindCoordsGluedToWordRejected`
      (terminators now expect `nil`, added the `0500 /59 1900 NAVIGATION` case);
      flipped `124-50-00ENNN`/`124-50-00EAREA` expectations in
      `TestFindCoordsDateMonthGlueRejected` and `TestFindCoordsOCRGlue` to `nil`.
- [x] Regressions green: `55-54.0N 019-03.0E`, `AREA 5121.00 N 00258.00 E ENDS`,
      `30N END`, `46-20.0NR142-2.0E`.

Closes #32
