### PR TITLE
chore: release v0.3.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [unreleased]
+## [v0.3.9] by 2026-06-08
 
 ### Changed
 


### PR DESCRIPTION
## v0.3.9

### Changed

- `FindCoords` no longer accepts a fully specified DMS candidate whose direction
  letter is glued to a trailing all-letter word: `59 1900 NAVIGATION` no longer
  yields a spurious `59 1900 N`, and NAVTEX terminators are dropped too
  (`124-50-00ENNN` returns nothing) — stripping them is the consumer's job.
  Direction letters followed by space/punctuation and OCR-glue bridges are
  unaffected. (#33, closes #32)

Tag + GitHub release follow once this merges.
